### PR TITLE
fix use of imported rollup-plugin-jspm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ npm install --save-dev rollup-plugin-jspm
 ```js
 // rollup.config.js
 import path from 'path';
-import babel from 'rollup-plugin-babel';
-import jspm from 'rollup-plugin-jspm';
+import babelRollup from 'rollup-plugin-babel';
+import jspmRollup from 'rollup-plugin-jspm';
 
 const basePath = path.resolve('components');
 
 export default {
   input: './main.js', // Will resolve to 'components/main.js'
   plugins: [
-    jspm({ 
+    jspmRollup({ 
       basePath, // defaults to process.cwd()
       env: { browser: true, node: false } // defaults to { node: true }
     }),
-    babel() // Compose with other Rollup plugins
+    babelRollup() // Compose with other Rollup plugins
   ]
 }
 


### PR DESCRIPTION
it slipped under the radar. "rollup-plugin-jspm" is imported as "jspm" but used as "jspmRollup"